### PR TITLE
Update groove-dl.glade

### DIFF
--- a/glade/groove-dl.glade
+++ b/glade/groove-dl.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="download_failed_list_store">
     <columns>
       <!-- column-name path -->


### PR DESCRIPTION
Glade require 3.10 instead of 3.12
